### PR TITLE
Use atom for Rustler crate name

### DIFF
--- a/lib/jsengine.ex
+++ b/lib/jsengine.ex
@@ -1,8 +1,7 @@
 defmodule JSEngine do
   use Rustler,
     otp_app: :jsengine,
-    crate: "jsengine",
-    path: "native/jsengine"
+    crate: :jsengine
 
   # NIFs - these are replaced by Rust implementations
   def create_env(), do: error()


### PR DESCRIPTION
Change crate parameter from string "jsengine" to atom :jsengine. This is the more idiomatic pattern for Rustler 0.30.0 and ensures proper crate discovery and compilation.